### PR TITLE
Fork properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,27 @@ openApi {
 ```
 
 # Building the plugin
+1. Clone the repo `git@github.com:springdoc/springdoc-openapi-gradle-plugin.git`
+2. Build and publish the plugin into your local maven repository by running the following 
+    ```
+    ./gradlew clean pTML
+   ```
+   
+# Testing the plugin
+1. Create a new spring boot application or use an existing spring boot app and follow the `How To Use` section above to configure this plugin.
+2. Update the version for the plugin to match the current version found in `build.gradle.kts`
 
-TODO
+    ```
+    id("org.springdoc.openapi-gradle-plugin") version "1.33.0-SNAPSHOT"
+    ```
+
+3. Add the following to the spring boot apps `settings.gradle`
+
+    ```
+    pluginManagement {
+        repositories {
+            mavenLocal()
+            gradlePluginPortal()
+        }
+    }
+    ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ openApi {
     outputDir.set(file("$buildDir/docs"))
     outputFileName.set("swagger.json")
     waitTimeInSeconds.set(10)
+    forkProperties.set("-Dspring.profiles.active=special")
 }
 ```
 
@@ -87,6 +88,30 @@ Parameter | Description | Required | Default
 `outputDir` | The output directory for the generated OpenAPI file | No | $buildDir - Your project's build dir
 `outputFileName` | The name of the output file with extension | No | openapi.json
 `waitTimeInSeconds` | Time to wait in seconds for your Spring Boot application to start, before we make calls to `apiDocsUrl` to download the OpenAPI doc | No | 30 seconds
+`forkProperites` | Any system property that you would normal need to start your spring boot application. Can either be a static string or a java Properties object | No | ""
+
+### Fork properties examples
+Fork properties allows you to send in anything that might be necessary to allow for the forked spring boot application that gets started
+to be able to start (profiles, other custom properties, etc etc)
+
+#### Static string
+```
+openApi {
+	forkProperties = "-Dspring.profiles.active=special -DstringPassedInForkProperites=true"
+}
+```
+
+#### Passing straight from gradle
+This allows for you to be able to just send in whatever you need when you generate docs. 
+
+`./gradlew clean generateOpenApiDocs -Dspring.profiles.active=special`
+
+and as long as the config looks as follows that value will be passed into the forked spring boot application.
+```
+openApi {
+	forkProperties = System.properties
+}
+```
 
 # Building the plugin
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     implementation(group = "com.google.code.gson", name = "gson", version = "2.8.6")
     implementation(group = "org.awaitility", name = "awaitility-kotlin", version = "4.0.2")
     implementation(files("$projectDir/libs/gradle-processes-0.5.0.jar"))
+
+    testImplementation(gradleTestKit())
+    testImplementation("junit:junit:4.13")
+    testImplementation("com.beust:klaxon:5.2")
 }
 
 gradlePlugin {

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -10,4 +10,5 @@ open class OpenApiExtension @Inject constructor(project: Project) {
     val outputFileName: Property<String> = project.objects.property(String::class.java)
     val outputDir: DirectoryProperty = project.objects.directoryProperty()
     val waitTimeInSeconds: Property<Int> = project.objects.property(Int::class.java)
+    val forkProperties: Property<Any> = project.objects.property(Any::class.java)
 }

--- a/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
+++ b/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
@@ -1,0 +1,220 @@
+package org.springdoc.openapi.gradle.plugin
+
+import com.beust.klaxon.JsonObject
+import com.beust.klaxon.Klaxon
+import com.beust.klaxon.Parser
+import org.gradle.internal.impldep.org.apache.commons.lang.RandomStringUtils
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.BuildTask
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.internal.FeatureCheckBuildResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileReader
+
+class OpenApiGradlePluginTest {
+    @Rule
+    @JvmField
+    var testProjectDir: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var projectTestDir: File
+    private lateinit var buildFile: File
+    private lateinit var projectBuildDir: File
+
+    private var baseBuildGradle = """plugins {
+            id 'org.springframework.boot' version '2.2.0.RELEASE'
+            id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+            id 'java'
+            id "com.github.johnrengelman.processes" version "0.5.0"
+            id("org.springdoc.openapi-gradle-plugin")
+        }
+        
+        group = 'com.example'
+        version = '0.0.1-SNAPSHOT'
+        sourceCompatibility = '8'
+        
+        repositories {
+            mavenCentral()
+        }
+        
+        dependencies {
+            implementation 'org.springframework.boot:spring-boot-starter-web'
+            implementation group: 'org.springdoc', name: 'springdoc-openapi-webmvc-core', version: '1.4.0'
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        val acceptanceTestProject = File(this.javaClass.classLoader.getResource("acceptance-project")!!.path)
+        projectTestDir = File(testProjectDir.newFolder(), "acceptence-project")
+
+        acceptanceTestProject.copyRecursively(projectTestDir)
+        buildFile = File(projectTestDir, "build.gradle")
+
+        projectBuildDir = File(projectTestDir, "build")
+        println("!!!!! $projectBuildDir !!!!!!!")
+    }
+
+    @Test
+    fun `default build no options`() {
+        buildFile.writeText(baseBuildGradle)
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(projectBuildDir, DEFAULT_OPEN_API_FILE_NAME)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 1)
+    }
+
+    @Test
+    fun `different output dir`() {
+        var specialOutputDir = File(projectTestDir, "specialDir")
+        specialOutputDir.mkdirs()
+
+        buildFile.writeText("""$baseBuildGradle
+            openApi{
+                outputDir = file("${specialOutputDir.path}")
+            }
+        """.trimMargin())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(specialOutputDir, DEFAULT_OPEN_API_FILE_NAME)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 1)
+    }
+
+    @Test
+    fun `different output file name`() {
+        var specialOutputJsonFileName = RandomStringUtils.randomAlphanumeric(15)
+
+        buildFile.writeText("""$baseBuildGradle
+            openApi{
+                outputFileName = "$specialOutputJsonFileName"
+            }
+        """.trimMargin())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(projectBuildDir, specialOutputJsonFileName)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 1)
+    }
+
+    @Test
+    fun `using forked properties`() {
+        buildFile.writeText("""$baseBuildGradle
+            openApi{
+                forkProperties = "-Dspring.profiles.active=multiple-endpoints"
+            }
+        """.trimMargin())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(projectBuildDir, DEFAULT_OPEN_API_FILE_NAME)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 2)
+    }
+
+    @Test
+    fun `using forked properties via System properties`() {
+        buildFile.writeText("""$baseBuildGradle
+            openApi{
+                forkProperties = System.properties
+            }
+        """.trimMargin())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs", "-Dspring.profiles.active=multiple-endpoints")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(projectBuildDir, DEFAULT_OPEN_API_FILE_NAME)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 2)
+    }
+
+    @Test
+    fun `configurable wait time`() {
+        buildFile.writeText("""$baseBuildGradle
+            openApi{
+                forkProperties = "-Dspring.profiles.active=slower"
+                waitTimeInSeconds = 60
+            }
+        """.trimMargin())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(projectBuildDir, DEFAULT_OPEN_API_FILE_NAME)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 1)
+    }
+
+    @Test
+    fun `using different api url`() {
+        buildFile.writeText("""$baseBuildGradle
+            openApi{
+                apiDocsUrl = "http://localhost:8080/secret-api-docs"
+                forkProperties = "-Dspring.profiles.active=different-url"
+            }
+        """.trimMargin())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectTestDir)
+            .withArguments("clean", "generateOpenApiDocs")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
+
+        val openApiJsonFile = File(projectBuildDir, DEFAULT_OPEN_API_FILE_NAME)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 1)
+    }
+
+    private fun assertOpenApiJsonFileIsAsExpected(openApiJsonFile: File, expectedNumberOfPaths: Int) {
+        val openApiJson = getOpenApiJsonAtLocation(openApiJsonFile)
+        assertEquals("3.0.1", openApiJson!!.string("openapi"))
+        assertEquals(expectedNumberOfPaths, openApiJson.obj("paths")!!.size)
+    }
+
+    private fun getOpenApiJsonAtLocation(path: File): JsonObject? {
+        return Parser.default().parse(FileReader(path)) as JsonObject
+    }
+
+    private fun getTaskByName(result: BuildResult, name: String): BuildTask? {
+        return result.tasks.find { it.path.contains(name) }
+    }
+}

--- a/src/test/resources/acceptance-project/.gitignore
+++ b/src/test/resources/acceptance-project/.gitignore
@@ -1,0 +1,32 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**
+!**/src/test/**
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/src/test/resources/acceptance-project/settings.gradle
+++ b/src/test/resources/acceptance-project/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'demo'

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,29 @@
+package com.example.demo;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import javax.annotation.PostConstruct;
+import java.time.Duration;
+
+@SpringBootApplication
+public class DemoApplication {
+
+	@Value("${slower:false}")
+	boolean slower;
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+	@PostConstruct
+	public void afterBeanStuff() throws InterruptedException {
+		if(slower) {
+			Duration waitTime = Duration.ofSeconds(40);
+			System.out.println("Waiting for " + waitTime + " before starting");
+			Thread.sleep(waitTime.toMillis());
+		}
+	}
+
+}

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/HelloWorldController.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/HelloWorldController.java
@@ -1,0 +1,13 @@
+package com.example.demo.endpoints;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/hello")
+public class HelloWorldController {
+
+    @GetMapping("/world")
+    public String helloWorld(){
+        return "Hello World!";
+    }
+}

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/ProfileController.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/ProfileController.java
@@ -1,0 +1,19 @@
+package com.example.demo.endpoints;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("multiple-endpoints")
+@RestController("/special")
+public class ProfileController {
+
+    @Value("${test.props}")
+    String profileRelatedValue;
+
+    @GetMapping("/")
+    public String special(){
+        return profileRelatedValue;
+    }
+}

--- a/src/test/resources/acceptance-project/src/main/resources/application-different-url.properties
+++ b/src/test/resources/acceptance-project/src/main/resources/application-different-url.properties
@@ -1,0 +1,1 @@
+springdoc.api-docs.path=/secret-api-docs

--- a/src/test/resources/acceptance-project/src/main/resources/application-multiple-endpoints.properties
+++ b/src/test/resources/acceptance-project/src/main/resources/application-multiple-endpoints.properties
@@ -1,0 +1,1 @@
+test.props=So very special

--- a/src/test/resources/acceptance-project/src/main/resources/application-slower.properties
+++ b/src/test/resources/acceptance-project/src/main/resources/application-slower.properties
@@ -1,0 +1,1 @@
+slower=true


### PR DESCRIPTION
Add ability to set forkProperties on the forked spring boot startup. Fixes #22 

Allows for 1 of 2 options
1. A static string of the properties you want to set

```
openApi {
	forkProperties = "-Dspring.profiles.active=special"
}
```

2. You can simply pass the values from whatever you sent to gradle
```
gw clean generateOpenApiDocs -Dspring.profiles.active=special
```

```
openApi {
	forkProperties = System.properties
}
```