### PR TITLE
FIX: Cannot use multiple forkProperties

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
@@ -36,7 +36,10 @@ open class OpenApiGradlePlugin : Plugin<Project> {
                     if (extension.forkProperties.isPresent) {
                         val element = extension.forkProperties.get()
                         if (element is String) {
-                            command.add(element)
+                            val elements = element
+                                .split("-D")
+                                .map { "-D${it.trim()}" }
+                            command.addAll(elements)
                         } else if (element is Properties) {
                             element.toMap().map { r -> "-D${r.key}=${r.value}" }.forEach { p -> command.add(p) }
                         } else {

--- a/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
+++ b/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
@@ -126,7 +126,7 @@ class OpenApiGradlePluginTest {
     fun `using forked properties`() {
         buildFile.writeText("""$baseBuildGradle
             openApi{
-                forkProperties = "-Dspring.profiles.active=multiple-endpoints"
+                forkProperties = "-Dspring.profiles.active=multiple-endpoints -Dsome.second.property=someValue"
             }
         """.trimMargin())
 
@@ -139,7 +139,7 @@ class OpenApiGradlePluginTest {
         assertEquals(TaskOutcome.SUCCESS, getTaskByName(result, "generateOpenApiDocs")?.outcome)
 
         val openApiJsonFile = File(projectBuildDir, DEFAULT_OPEN_API_FILE_NAME)
-        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 2)
+        assertOpenApiJsonFileIsAsExpected(openApiJsonFile, 3)
     }
 
     @Test

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/ConditionalController.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/ConditionalController.java
@@ -1,0 +1,15 @@
+package com.example.demo.endpoints;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+@ConditionalOnProperty(value = {"some.second.property"}, havingValue = "someValue")
+@RestController("/conditional")
+public class ConditionalController {
+
+    @GetMapping("/conditional")
+    public String conditional(){
+        return "conditional";
+    }
+}


### PR DESCRIPTION
When adding multiple properties as a single String in forkProperties configuration value, then no property is used at all, because they have to be defined as separated values in the command list.