### PR TITLE
Add ability to generate multiple OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ openApi {
     outputFileName.set("swagger.json")
     waitTimeInSeconds.set(10)
     forkProperties.set("-Dspring.profiles.active=special")
+    groupedApiMappings.set(["https://localhost:8080/v3/api-docs/groupA" to "swagger-groupA.json",
+                            "https://localhost:8080/v3/api-docs/groupB" to "swagger-groupB.json"])
 }
 ```
 
@@ -89,6 +91,7 @@ Parameter | Description | Required | Default
 `outputFileName` | The name of the output file with extension | No | openapi.json
 `waitTimeInSeconds` | Time to wait in seconds for your Spring Boot application to start, before we make calls to `apiDocsUrl` to download the OpenAPI doc | No | 30 seconds
 `forkProperties` | Any system property that you would normal need to start your spring boot application. Can either be a static string or a java Properties object | No | ""
+`groupedApiMappings` | A map of URLs (from where the OpenAPI docs can be downloaded) to output file names | No | []
 
 ### Fork properties examples
 Fork properties allows you to send in anything that might be necessary to allow for the forked spring boot application that gets started
@@ -112,6 +115,9 @@ openApi {
 	forkProperties = System.properties
 }
 ```
+
+### Grouped API Mappings Notes
+The `groupedApiMappings` customization allows you to specify multiple URLs/file names for use within this plugin. This configures the plugin to ignore the `apiDocsUrl` and `outputFileName` parameters and only use those found in `groupedApiMappings`. The plugin will then attempt to download each OpenAPI doc in turn as it would for a single OpenAPI doc.
 
 # Building the plugin
 1. Clone the repo `git@github.com:springdoc/springdoc-openapi-gradle-plugin.git`

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -2,6 +2,7 @@ package org.springdoc.openapi.gradle.plugin
 
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
@@ -11,4 +12,5 @@ open class OpenApiExtension @Inject constructor(project: Project) {
     val outputDir: DirectoryProperty = project.objects.directoryProperty()
     val waitTimeInSeconds: Property<Int> = project.objects.property(Int::class.java)
     val forkProperties: Property<Any> = project.objects.property(Any::class.java)
+    val groupedApiMappings: MapProperty<String, String> = project.objects.mapProperty(String::class.java, String::class.java)
 }

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/config/GroupedConfiguration.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/config/GroupedConfiguration.java
@@ -1,0 +1,27 @@
+package com.example.demo;
+
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("multiple-grouped-apis")
+@Configuration
+public class GroupedConfiguration {
+
+    @Bean
+    public GroupedOpenApi groupA() {
+        return GroupedOpenApi.builder()
+                             .group("groupA")
+                             .pathsToMatch("/groupA/**")
+                             .build();
+    }
+
+    @Bean
+    public GroupedOpenApi groupB() {
+        return GroupedOpenApi.builder()
+                             .group("groupB")
+                             .pathsToMatch("/groupB/**")
+                             .build();
+    }
+}

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/GroupedController.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/GroupedController.java
@@ -1,0 +1,25 @@
+package com.example.demo.endpoints;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("multiple-grouped-apis")
+@RestController("/grouped")
+public class GroupedController {
+
+    @GetMapping("/groupA")
+    public String groupA(){
+        return "groupA";
+    }
+
+    @GetMapping("/groupB/first")
+    public String groupB_first(){
+        return "groupB_first";
+    }
+
+    @GetMapping("/groupB/second")
+    public String groupB_second(){
+        return "groupB_second";
+    }
+}

--- a/src/test/resources/acceptance-project/src/main/resources/application-multiple-grouped-apis.properties
+++ b/src/test/resources/acceptance-project/src/main/resources/application-multiple-grouped-apis.properties
@@ -1,0 +1,1 @@
+test.props=So very special


### PR DESCRIPTION
This commit adds a new extension property `groupedApiMappings` allowing a user of this plugin to specify multiple mappings of api url to file name. This is intended for use in projects utilising the springdoc GroupedOpenApi feature.

When the `groupedApiMappings` property is specified the single api properties `apiDocsUrl` and `outputFileName` are ignored. The plugin attempts to download each mapping in turn.