### PR TITLE
Make plugin work under Gradle 7

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/AnnotatedFork.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/AnnotatedFork.kt
@@ -1,0 +1,43 @@
+package org.springdoc.openapi.gradle.plugin
+
+import com.github.jengelman.gradle.plugins.processes.tasks.Fork
+import groovy.lang.MetaClass
+import org.codehaus.groovy.runtime.InvokerHelper
+import org.gradle.api.tasks.Internal
+import org.gradle.process.CommandLineArgumentProvider
+
+/**
+ * Extends the Fork task from the gradle-processes plugin to be compatible with Gradle 7.
+ * The functionality of the class remains exactly the same; it was just missing an annotation
+ * on the [getArgumentProviders] method and the annotation is mandatory in Gradle 7.
+ *
+ * Since the original class is written in Groovy, we also need to implement some internal
+ * Groovy methods that get added to Groovy classes via bytecode manipulation.
+ */
+open class AnnotatedFork : Fork() {
+  private var metaClass: MetaClass? = null
+
+  override fun invokeMethod(method: String?, args: Any?): Any? {
+    return InvokerHelper.invokeMethod(this, method, args)
+  }
+
+  override fun getProperty(property: String?): Any? {
+    return InvokerHelper.getProperty(this, property)
+  }
+
+  override fun getMetaClass(): MetaClass? {
+    if (metaClass == null) {
+      metaClass = InvokerHelper.getMetaClass(javaClass)
+    }
+    return metaClass
+  }
+
+  override fun setMetaClass(newMetaClass: MetaClass?) {
+    metaClass = newMetaClass
+  }
+
+  @Internal
+  override fun getArgumentProviders(): MutableList<CommandLineArgumentProvider>? {
+    return super.getArgumentProviders()
+  }
+}

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
@@ -1,6 +1,5 @@
 package org.springdoc.openapi.gradle.plugin
 
-import com.github.jengelman.gradle.plugins.processes.tasks.Fork
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logging
@@ -26,7 +25,7 @@ open class OpenApiGradlePlugin : Plugin<Project> {
 			}
 
 			// Create a forked version spring boot run task
-			val forkedSpringBoot = project.tasks.register(FORKED_SPRING_BOOT_RUN_TASK_NAME, Fork::class.java) { fork ->
+			val forkedSpringBoot = project.tasks.register(FORKED_SPRING_BOOT_RUN_TASK_NAME, AnnotatedFork::class.java) { fork ->
 				fork.dependsOn(bootJarTask)
 
 				fork.onlyIf {


### PR DESCRIPTION
Gradle 7 requires that task properties be annotated to indicate how they should be
treated when calculating what artifacts need to be rebuilt. One of the methods in
the gradle-processes plugin was missing an annotation, which caused the plugin to
bomb out under Gradle 7.

Fix it by subclassing the task in question and annotating the method.