### PR TITLE
feat(yaml): Add yaml support under actuator endpoint

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -74,7 +74,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
             logger.info("Generating OpenApi Docs..")
             val response: Response = khttp.get(url)
 
-            val isYaml = url.toLowerCase().matches(Regex(".+\\.?yaml$"))
+            val isYaml = url.toLowerCase().matches(Regex(".+[./]yaml$"))
             val apiDocs = if (isYaml) response.text else prettifyJson(response)
 
             val outputFile = outputDir.file(fileName).get().asFile

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -74,7 +74,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
             logger.info("Generating OpenApi Docs..")
             val response: Response = khttp.get(url)
 
-            val isYaml = url.toLowerCase().contains(".yaml")
+            val isYaml = url.toLowerCase().matches(Regex(".+\\.?yaml$"))
             val apiDocs = if (isYaml) response.text else prettifyJson(response)
 
             val outputFile = outputDir.file(fileName).get().asFile


### PR DESCRIPTION
Here I implement the code to add the support to generates YAML from the actuator endpoint.

closes #60