### PR TITLE
Fix wrong java executable used for forked process. Resolves #63

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
 	`java-gradle-plugin`
 	id("com.gradle.plugin-publish") version "0.14.0"
 	id("org.sonarqube") version "3.1.1"
-	kotlin("jvm") version "1.4.31"
+	kotlin("jvm") version "1.5.31"
 	`maven-publish`
 	id("com.github.ben-manes.versions") version "0.38.0"
 	id("io.gitlab.arturbosch.detekt") version "1.16.0"


### PR DESCRIPTION
Currently, the forked process (`forkedSpringBootRun`) uses the default Java execution file (`java`). It is a problem if the gradle main process targets a different (newer) Java version, because in this case the generated binaries are not compatible with the default Java.

### Real life example

My default Java is Java 11
```
java -version
openjdk version "11.0.13" 2021-10-19
OpenJDK Runtime Environment (build 11.0.13+8)
OpenJDK 64-Bit Server VM (build 11.0.13+8, mixed mode)
```
The current project target version is 17, thus the project build is called like this:
```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk ./gradlew ...
```
But, if I call OpenAPI generation like this:
```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk ./gradlew generateOpenApiDocs                   
Exception in thread "main" java.lang.UnsupportedClassVersionError: de/knipp/jive/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
        at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:555)
        at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
        at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:151)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:398)
        at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:46)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:107)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
        at org.springframework.boot.loader.PropertiesLauncher.main(PropertiesLauncher.java:467)
```
an error occur because the application was compiled with Java 17, but forked process tries to start it with Java 11.

So I've created a patch, which starts forked process with the same Java version as used by Gradle. Please integrate this!