### PR TITLE
introduce customBootRun property for customizing runtime parameter for Spring application

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,29 +71,36 @@ openApi {
     outputDir.set(file("$buildDir/docs"))
     outputFileName.set("swagger.json")
     waitTimeInSeconds.set(10)
-    forkProperties.set("-Dspring.profiles.active=special")
     groupedApiMappings.set(["https://localhost:8080/v3/api-docs/groupA" to "swagger-groupA.json",
                             "https://localhost:8080/v3/api-docs/groupB" to "swagger-groupB.json"])
+    customBootRun {
+        args.set(["--spring.profiles.active=special"]) 
+    }
 }
 ```
 
-Parameter | Description | Required | Default
---------- | ----------- | -------- | -------
-`apiDocsUrl` | The URL from where the OpenAPI doc can be downloaded | No | http://localhost:8080/v3/api-docs
-`outputDir` | The output directory for the generated OpenAPI file | No | $buildDir - Your project's build dir
-`outputFileName` | The name of the output file with extension | No | openapi.json
-`waitTimeInSeconds` | Time to wait in seconds for your Spring Boot application to start, before we make calls to `apiDocsUrl` to download the OpenAPI doc | No | 30 seconds
-`forkProperties` | Any system property that you would normal need to start your spring boot application. Can either be a static string or a java Properties object | No | ""
-`groupedApiMappings` | A map of URLs (from where the OpenAPI docs can be downloaded) to output file names | No | []
+| Parameter            | Description                                                                                                                         | Required | Default                              |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------------|
+| `apiDocsUrl`         | The URL from where the OpenAPI doc can be downloaded                                                                                | No       | http://localhost:8080/v3/api-docs    |
+| `outputDir`          | The output directory for the generated OpenAPI file                                                                                 | No       | $buildDir - Your project's build dir |
+| `outputFileName`     | The name of the output file with extension                                                                                          | No       | openapi.json                         |
+| `waitTimeInSeconds`  | Time to wait in seconds for your Spring Boot application to start, before we make calls to `apiDocsUrl` to download the OpenAPI doc | No       | 30 seconds                           |
+| `groupedApiMappings` | A map of URLs (from where the OpenAPI docs can be downloaded) to output file names                                                  | No       | []                                   |
+| `customBootRun`      | Any bootRun property that you would normal need to start your spring boot application.                                              | No       | (N/A)                                |
 
-### Fork properties examples
-Fork properties allows you to send in anything that might be necessary to allow for the forked spring boot application that gets started
-to be able to start (profiles, other custom properties, etc etc)
+### `customBootRun` properties examples
+`customBootRun` allows you to send in the properties that might be necessary to allow for the forked spring boot application that gets started
+to be able to start (profiles, other custom properties, etc.)
+`customBootRun` allows you can specify bootRun style parameter, such as `args`, `jvmArgs`, `systemProperties` and `workingDir`.
+If you don't specify `customBootRun` parameter, this plugin uses the parameter specified to `bootRun` in Spring Boot Gradle Plugin.
 
-#### Static string
+#### Passing static args
+This allows for you to be able to just send the static properties when executing Spring application in `generateOpenApiDocs`.
 ```
 openApi {
-	forkProperties = "-Dspring.profiles.active=special -DstringPassedInForkProperites=true"
+    customBootRun {
+        args = ["--spring.profiles.active=special"] 
+    }
 }
 ```
 
@@ -105,7 +112,9 @@ This allows for you to be able to just send in whatever you need when you genera
 and as long as the config looks as follows that value will be passed into the forked spring boot application.
 ```
 openApi {
-	forkProperties = System.properties
+    customBootRun {
+         systemProperties = System.properties
+    }
 }
 ```
 

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -1,7 +1,11 @@
 package org.springdoc.openapi.gradle.plugin
 
+import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import javax.inject.Inject
@@ -12,4 +16,20 @@ open class OpenApiExtension @Inject constructor(project: Project) {
     val outputDir: DirectoryProperty = project.objects.directoryProperty()
     val waitTimeInSeconds: Property<Int> = project.objects.property(Int::class.java)
     val groupedApiMappings: MapProperty<String, String> = project.objects.mapProperty(String::class.java, String::class.java)
+    val customBootRun: CustomBootRunAction = project.objects.newInstance(CustomBootRunAction::class.java, project)
+    fun customBootRun(action: Action<CustomBootRunAction>) {
+        action.execute(customBootRun)
+    }
+}
+
+open class CustomBootRunAction @Inject constructor(
+    project: Project,
+) {
+    val systemProperties: MapProperty<String, Any> = project.objects.mapProperty(String::class.java, Any::class.java)
+    val workingDir: RegularFileProperty = project.objects.fileProperty()
+    val mainClass: Property<String> = project.objects.property(String::class.java)
+    val args: ListProperty<String> = project.objects.listProperty(String::class.java)
+    val classpath: ConfigurableFileCollection = project.objects.fileCollection()
+    val jvmArgs: ListProperty<String> = project.objects.listProperty(String::class.java)
+    val environment: MapProperty<String, Any> = project.objects.mapProperty(String::class.java, Any::class.java)
 }

--- a/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
+++ b/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
@@ -3,7 +3,6 @@ package org.springdoc.openapi.gradle.plugin
 import com.beust.klaxon.JsonObject
 import com.beust.klaxon.Parser
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.gradle.internal.impldep.org.apache.commons.lang.RandomStringUtils
@@ -123,6 +122,23 @@ class OpenApiGradlePluginTest {
     }
 
     @Test
+    fun `using forked properties via System properties with customBootRun`() {
+        buildFile.writeText(
+            """$baseBuildGradle
+            openApi {
+                customBootRun {
+                    systemProperties = System.properties
+                }
+            }
+        """.trimMargin()
+        )
+
+        assertEquals(TaskOutcome.SUCCESS, openApiDocsTask(runTheBuild("-Dspring.profiles.active=multiple-endpoints")).outcome)
+        assertOpenApiJsonFile(2)
+    }
+
+
+    @Test
     fun `configurable wait time`() {
         buildFile.writeText(
             """$baseBuildGradle
@@ -155,6 +171,24 @@ class OpenApiGradlePluginTest {
         assertEquals(TaskOutcome.SUCCESS, openApiDocsTask(runTheBuild()).outcome)
         assertOpenApiJsonFile(1)
     }
+
+    @Test
+    fun `using different api url via customBootRun`() {
+        buildFile.writeText(
+            """$baseBuildGradle
+            openApi{
+                apiDocsUrl = "http://localhost:8080/secret-api-docs"
+                customBootRun {
+                    args = ["--spring.profiles.active=different-url"]
+                }
+            }
+        """.trimMargin()
+        )
+
+        assertEquals(TaskOutcome.SUCCESS, openApiDocsTask(runTheBuild()).outcome)
+        assertOpenApiJsonFile(1)
+    }
+
 
     @Test
     fun `yaml generation`() {


### PR DESCRIPTION
Motivation:

resolve #75

Modification:

introduce `customBootRun`. This is propety-customizer for `bootRun` which is used in this plugin.
the users can specify custom parameter like following:
```groovy
openApi {
    customBootRun {
        args = ["--spring.profiles.active=different-url"] 
    }
}
```

If the parameter is not specified by user, this plugin uses the parameter specified in `bootRun` in Spring Boot Gradle Plugin instead.
As a result, we can satisfy the following requirement this plugin users.

- the case that the users need specifing static properties to generate openapi schema(by the way, this includes me!)
- the case that the users need to try this plugin quickly

Notes:

- springdoc-openapi-gradle-plugin 1.3.4 had removed `forkProperties`. it is breaking changes for the users... also the user needs to migrate to `customBootRun` to upgrade this plugin continuously, so I recommend that you might want to release this changes as version 1.4.0. 
