### PR TITLE
stop the forked task after the generation of the OpenAPI spec

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
@@ -66,6 +66,9 @@ open class OpenApiGradlePlugin : Plugin<Project> {
 			) { openApiGenTask ->
 				openApiGenTask.dependsOn(forkedSpringBoot)
 			}
+
+			// The forked task need to be terminated as soon as my task is finished
+			forkedSpringBoot.get().stopAfter = project.tasks.named(OPEN_API_TASK_NAME)
 		}
 	}
 }


### PR DESCRIPTION
Currently, the forked task `forkedSpringBootRun` is not automatically terminated after the generation of the OpenAPI specification.

### The problem description
I have a backend part of my application (REST interface), which is implemented with the aid of SpringBoot. The frontend part is just a Vue SPA, developed with the aid of [Vite](https://vitejs.dev/). The `springdoc-openapi-gradle-plugin` is used to generate the frontend code to communicate with the rest interface. So, the generation task is a dependency for the frontend development server. Currently, while the frontend development server is running the backend process is running too (because it is not automatically terminated), although the generation of the code is finished. In most cases it is not a problem, but if I need to start a backend in debug mode, it is impossible (because it is already started just normal for the code generation).

So, the PR solves this problem by terminating the forked process after the generation is finished. It was already the case before switching to `gradle-execfork-plugin`, thus the PR should be treated as a regression fix.