### PR TITLE
Define output file name is openapi.yaml but content is json.

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -74,7 +74,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
             logger.info("Generating OpenApi Docs..")
             val response: Response = khttp.get(url)
 
-            val isYaml = url.toLowerCase().matches(Regex(".+[./]yaml(/.+)*"))
+            val isYaml = fileName.toLowerCase().matches(Regex(".+[./]yaml(/.+)*"))
             val apiDocs = if (isYaml) response.text else prettifyJson(response)
 
             val outputFile = outputDir.file(fileName).get().asFile


### PR DESCRIPTION
As design output file allow json or yaml format, when output file with ext is yaml but it still generated json format. It's confusing about defination output file.

I checked generation code, it's using url to check output format json or yaml. I think format generator should be base on output file.