### PR TITLE
Removes khttp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,6 @@ publishing {
 
 dependencies {
 	implementation(kotlin("reflect"))
-	implementation("khttp:khttp:1.0.0")
 	implementation("com.google.code.gson:gson:2.8.6")
 	implementation("org.awaitility:awaitility-kotlin:4.0.3")
 	implementation("com.github.psxpaul:gradle-execfork-plugin:0.2.0")

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -69,8 +69,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
                 waitTimeInSeconds.get().toLong(),
                 SECONDS
             ) until {
-                val url = URL(url)
-                val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+                val connection: HttpURLConnection = URL(url).openConnection() as HttpURLConnection
                 connection.requestMethod = "GET"
                 connection.connect()
                 val statusCode = connection.responseCode

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -77,8 +77,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
                 statusCode < MAX_HTTP_STATUS_CODE
             }
             logger.info("Generating OpenApi Docs..")
-            val url = URL(url)
-            val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+            val connection: HttpURLConnection = URL(url).openConnection() as HttpURLConnection
             connection.requestMethod = "GET"
             connection.connect()
 


### PR DESCRIPTION
It seems we're currently only using khttp for something pretty simple. 
Would we be able to replace it with something like this? Not sure if there were plans to use khttp for something else. 

Potentially for https://github.com/springdoc/springdoc-openapi-gradle-plugin/issues/91