### PR TITLE
Fix a few gradle issues

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -26,7 +26,6 @@ open class OpenApiExtension @Inject constructor(
 
 open class CustomBootRunAction @Inject constructor(
     objects: ObjectFactory,
-    layout: ProjectLayout,
 ) {
     val systemProperties: MapProperty<String, Any> = objects.mapProperty(String::class.java, Any::class.java)
     val workingDir: DirectoryProperty = objects.directoryProperty()
@@ -35,7 +34,4 @@ open class CustomBootRunAction @Inject constructor(
     val classpath: ConfigurableFileCollection = objects.fileCollection()
     val jvmArgs: ListProperty<String> = objects.listProperty(String::class.java)
     val environment: MapProperty<String, Any> = objects.mapProperty(String::class.java, Any::class.java)
-    init {
-        workingDir.convention(layout.buildDirectory.dir("openapi"))
-    }
 }

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -1,35 +1,41 @@
 package org.springdoc.openapi.gradle.plugin
 
 import org.gradle.api.Action
-import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-open class OpenApiExtension @Inject constructor(project: Project) {
-    val apiDocsUrl: Property<String> = project.objects.property(String::class.java)
-    val outputFileName: Property<String> = project.objects.property(String::class.java)
-    val outputDir: DirectoryProperty = project.objects.directoryProperty()
-    val waitTimeInSeconds: Property<Int> = project.objects.property(Int::class.java)
-    val groupedApiMappings: MapProperty<String, String> = project.objects.mapProperty(String::class.java, String::class.java)
-    val customBootRun: CustomBootRunAction = project.objects.newInstance(CustomBootRunAction::class.java, project)
+open class OpenApiExtension @Inject constructor(
+    objects: ObjectFactory,
+) {
+    val apiDocsUrl: Property<String> = objects.property(String::class.java)
+    val outputFileName: Property<String> = objects.property(String::class.java)
+    val outputDir: DirectoryProperty = objects.directoryProperty()
+    val waitTimeInSeconds: Property<Int> = objects.property(Int::class.java)
+    val groupedApiMappings: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
+    val customBootRun: CustomBootRunAction = objects.newInstance(CustomBootRunAction::class.java)
     fun customBootRun(action: Action<CustomBootRunAction>) {
         action.execute(customBootRun)
     }
 }
 
 open class CustomBootRunAction @Inject constructor(
-    project: Project,
+    objects: ObjectFactory,
+    layout: ProjectLayout,
 ) {
-    val systemProperties: MapProperty<String, Any> = project.objects.mapProperty(String::class.java, Any::class.java)
-    val workingDir: RegularFileProperty = project.objects.fileProperty()
-    val mainClass: Property<String> = project.objects.property(String::class.java)
-    val args: ListProperty<String> = project.objects.listProperty(String::class.java)
-    val classpath: ConfigurableFileCollection = project.objects.fileCollection()
-    val jvmArgs: ListProperty<String> = project.objects.listProperty(String::class.java)
-    val environment: MapProperty<String, Any> = project.objects.mapProperty(String::class.java, Any::class.java)
+    val systemProperties: MapProperty<String, Any> = objects.mapProperty(String::class.java, Any::class.java)
+    val workingDir: DirectoryProperty = objects.directoryProperty()
+    val mainClass: Property<String> = objects.property(String::class.java)
+    val args: ListProperty<String> = objects.listProperty(String::class.java)
+    val classpath: ConfigurableFileCollection = objects.fileCollection()
+    val jvmArgs: ListProperty<String> = objects.listProperty(String::class.java)
+    val environment: MapProperty<String, Any> = objects.mapProperty(String::class.java, Any::class.java)
+    init {
+        workingDir.convention(layout.buildDirectory.dir("openapi"))
+    }
 }

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -40,17 +40,17 @@ open class OpenApiGeneratorTask : DefaultTask() {
         description = OPEN_API_TASK_DESCRIPTION
         group = GROUP_NAME
         // load my extensions
-        val extension: OpenApiExtension = project.extensions.run { getByName(EXTENSION_NAME) as OpenApiExtension }
+        val extension: OpenApiExtension = project.extensions.getByName(EXTENSION_NAME) as OpenApiExtension
 
         // set a default value if not provided
         val defaultOutputDir = project.objects.directoryProperty()
-        defaultOutputDir.set(project.buildDir)
+        defaultOutputDir.convention(project.layout.buildDirectory)
 
-        apiDocsUrl.set(extension.apiDocsUrl.getOrElse(DEFAULT_API_DOCS_URL))
-        outputFileName.set(extension.outputFileName.getOrElse(DEFAULT_OPEN_API_FILE_NAME))
-        groupedApiMappings.set(extension.groupedApiMappings.getOrElse(emptyMap()))
-        outputDir.set(extension.outputDir.getOrElse(defaultOutputDir.get()))
-        waitTimeInSeconds.set(extension.waitTimeInSeconds.getOrElse(DEFAULT_WAIT_TIME_IN_SECONDS))
+        apiDocsUrl.convention(extension.apiDocsUrl.getOrElse(DEFAULT_API_DOCS_URL))
+        outputFileName.convention(extension.outputFileName.getOrElse(DEFAULT_OPEN_API_FILE_NAME))
+        groupedApiMappings.convention(extension.groupedApiMappings.getOrElse(emptyMap()))
+        outputDir.convention(extension.outputDir.getOrElse(defaultOutputDir.get()))
+        waitTimeInSeconds.convention(extension.waitTimeInSeconds.getOrElse(DEFAULT_WAIT_TIME_IN_SECONDS))
     }
 
     @TaskAction

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -44,7 +44,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
 
         // set a default value if not provided
         val defaultOutputDir = project.objects.directoryProperty()
-        defaultOutputDir.convention(project.layout.buildDirectory)
+        defaultOutputDir.convention(project.layout.buildDirectory.dir("openapi"))
 
         apiDocsUrl.convention(extension.apiDocsUrl.getOrElse(DEFAULT_API_DOCS_URL))
         outputFileName.convention(extension.outputFileName.getOrElse(DEFAULT_OPEN_API_FILE_NAME))


### PR DESCRIPTION
* Changes workingDir from file property to directory property
* Changes sets to conventions
* Registers tasks before afterEvaluate (but continue to configure them in afterEvaluate)
* Changes workingDir fallback to tempDir, as the upstream plugin is erroneously setting workingDir to `@Input` (instead of `@Internal`)
* Sets default output dir to openapi instead of buildDir to prevent issues with gradle's dependency tracking