### PR TITLE
Show more informative error message on parsing error

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -2,6 +2,7 @@ package org.springdoc.openapi.gradle.plugin
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
+import com.google.gson.JsonSyntaxException
 import org.awaitility.Durations
 import org.awaitility.core.ConditionTimeoutException
 import org.awaitility.kotlin.*
@@ -95,7 +96,12 @@ open class OpenApiGeneratorTask : DefaultTask() {
 
     private fun prettifyJson(response: String): String {
         val gson = GsonBuilder().setPrettyPrinting().create()
-        val googleJsonObject = gson.fromJson(response, JsonObject::class.java)
-        return gson.toJson(googleJsonObject)
+        try {
+            val googleJsonObject = gson.fromJson(response, JsonObject::class.java)
+            return gson.toJson(googleJsonObject)
+        } catch (e: RuntimeException) {
+            throw JsonSyntaxException("Failed to parse the API docs response string. " +
+                    "Please ensure that the response is in the correct format. response=$response", e)
+        }
     }
 }

--- a/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/HelloWorldController.java
+++ b/src/test/resources/acceptance-project/src/main/java/com/example/demo/endpoints/HelloWorldController.java
@@ -1,12 +1,16 @@
 package com.example.demo.endpoints;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/hello")
+@RequestMapping("/hello")
 public class HelloWorldController {
 
     @GetMapping("/world")
+    @ResponseBody
     public String helloWorld() {
         return "Hello World!";
     }


### PR DESCRIPTION
If the API documentation JSON file is incorrect, it only shows GSON's error message, which is quite difficult to understand at first.

Here is the old error message:

Caused by: com.google.gson.JsonSyntaxException:
Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive