### PR TITLE
Add dependency on inspectClassesForKotlinIC explicitly

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/Constants.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/Constants.kt
@@ -8,6 +8,7 @@ const val SPRING_BOOT_RUN_TASK_NAME = "bootRun"
 const val SPRING_BOOT_RUN_MAIN_CLASS_NAME_TASK_NAME = "bootRunMainClassName"
 const val SPRING_BOOT_3_RUN_MAIN_CLASS_NAME_TASK_NAME = "bootRun"
 const val FORKED_SPRING_BOOT_RUN_TASK_NAME = "forkedSpringBootRun"
+const val INSPECT_IC_CLASSES_TASK_NAME = "inspectClassesForKotlinIC"
 
 const val DEFAULT_API_DOCS_URL = "http://localhost:8080/v3/api-docs"
 const val DEFAULT_OPEN_API_FILE_NAME = "openapi.json"

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
@@ -38,6 +38,9 @@ open class OpenApiGradlePlugin : Plugin<Project> {
         // Create a forked version spring boot run task
         val forkedSpringBoot = tasks.register(FORKED_SPRING_BOOT_RUN_TASK_NAME, JavaExecFork::class.java) { fork ->
             fork.dependsOn(bootRunMainClassNameTask)
+            if (INSPECT_IC_CLASSES_TASK_NAME in tasks.names) {
+                fork.dependsOn(INSPECT_IC_CLASSES_TASK_NAME)
+            }
             fork.onlyIf { needToFork(bootRunTask, customBootRun, fork) }
         }
 


### PR DESCRIPTION
Motivation:
resolve: #109

Modification:
Add dependency on `inspectClassesForKotlinIC` to `forkedSpringBootRun` if the project uses Kotlin.

Note:
I faced the same error as #109 when I upgraded Gradle to v8 with the kotlin project.
I understand that there is a workaround discussed in #102.
But if you could add the dependency to "inspectClassesForKotlinIC" in your plugin, it would be very nice for users.
Please review this PR, and I want your idea. Thanks.