### PR TITLE
Eliminate afterEvaluate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.springdoc"
-version = "1.6.0"
+version = "1.6.1-SNAPSHOT"
 
 sonarqube {
 	properties {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
 	`java-gradle-plugin`
 	id("com.gradle.plugin-publish") version "0.14.0"
 	id("org.sonarqube") version "3.1.1"
-	kotlin("jvm") version "1.4.31"
+	kotlin("jvm") version "1.8.21"
 	`maven-publish`
 	id("com.github.ben-manes.versions") version "0.38.0"
 	id("io.gitlab.arturbosch.detekt") version "1.16.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request eliminates the usage of afterEvaluate that is causing all sorts of  side-effects especially with implementing convention plugins configuring defaults