### PR TITLE
Make task properties completely lazy and move the default values to the conventions of the extension properties.

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -3,6 +3,7 @@ package org.springdoc.openapi.gradle.plugin
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -11,6 +12,7 @@ import javax.inject.Inject
 
 open class OpenApiExtension @Inject constructor(
 	objects: ObjectFactory,
+	layout: ProjectLayout
 ) {
 	val apiDocsUrl: Property<String> = objects.property(String::class.java)
 	val outputFileName: Property<String> = objects.property(String::class.java)
@@ -20,6 +22,14 @@ open class OpenApiExtension @Inject constructor(
 		objects.mapProperty(String::class.java, String::class.java)
 	val customBootRun: CustomBootRunAction =
 		objects.newInstance(CustomBootRunAction::class.java)
+
+	init {
+		apiDocsUrl.convention(DEFAULT_API_DOCS_URL)
+		outputFileName.convention(DEFAULT_OPEN_API_FILE_NAME)
+		outputDir.convention(layout.buildDirectory)
+		waitTimeInSeconds.convention(DEFAULT_WAIT_TIME_IN_SECONDS)
+		groupedApiMappings.convention(emptyMap())
+	}
 
 	fun customBootRun(action: Action<CustomBootRunAction>) {
 		action.execute(customBootRun)

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -23,7 +23,6 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.time.Duration
 import java.time.temporal.ChronoUnit.SECONDS
-import java.util.*
 
 private const val MAX_HTTP_STATUS_CODE = 299
 
@@ -50,23 +49,11 @@ open class OpenApiGeneratorTask : DefaultTask() {
 		val extension: OpenApiExtension =
 			project.extensions.getByName(EXTENSION_NAME) as OpenApiExtension
 
-		// set a default value if not provided
-		val defaultOutputDir = project.objects.directoryProperty()
-		defaultOutputDir.set(project.buildDir)
-
-		apiDocsUrl.convention(extension.apiDocsUrl.getOrElse(DEFAULT_API_DOCS_URL))
-		outputFileName.convention(
-			extension.outputFileName.getOrElse(
-				DEFAULT_OPEN_API_FILE_NAME
-			)
-		)
-		groupedApiMappings.convention(extension.groupedApiMappings.getOrElse(emptyMap()))
-		outputDir.convention(extension.outputDir.getOrElse(defaultOutputDir.get()))
-		waitTimeInSeconds.convention(
-			extension.waitTimeInSeconds.getOrElse(
-				DEFAULT_WAIT_TIME_IN_SECONDS
-			)
-		)
+		apiDocsUrl.convention(extension.apiDocsUrl)
+		outputFileName.convention(extension.outputFileName)
+		groupedApiMappings.convention(extension.groupedApiMappings)
+		outputDir.convention(extension.outputDir)
+		waitTimeInSeconds.convention(extension.waitTimeInSeconds)
 	}
 
 	@TaskAction

--- a/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
+++ b/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
@@ -103,6 +103,27 @@ class OpenApiGradlePluginTest {
 	}
 
 	@Test
+	fun `accessing the task does not break later configuration`() {
+		val specialOutputDir = File(projectTestDir, "specialDir")
+		specialOutputDir.mkdirs()
+
+		buildFile.writeText(
+			"""$baseBuildGradle
+            tasks.withType(org.springdoc.openapi.gradle.plugin.OpenApiGeneratorTask.class) {
+                dependsOn("clean")
+            }
+
+            openApi{
+                outputDir = file("${specialOutputDir.toURI().path}")
+            }
+        """.trimMargin()
+		)
+
+		assertEquals(TaskOutcome.SUCCESS, openApiDocsTask(runTheBuild()).outcome)
+		assertOpenApiJsonFile(1, buildDir = specialOutputDir)
+	}
+
+	@Test
 	fun `using properties`() {
 		buildFile.writeText(
 			"""$baseBuildGradle


### PR DESCRIPTION
Fixes #117