### PR TITLE
Add toolchain auto-provisioning

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,3 +6,7 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 }
+
+plugins {
+	id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+}


### PR DESCRIPTION
I just pulled the project locally and tried to build it as explained in the README file ```./gradlew clean pTML```

I then had the following error: 
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':publishPluginMavenPublicationToMavenLocal'.
> Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
   > No matching toolchains found for requested specification: {languageVersion=8, vendor=any, implementation=vendor-specific} for MAC_OS on x86_64.
      > No locally installed toolchains match and toolchain download repositories have not been configured.

* Try:
> Learn more about toolchain auto-detection at https://docs.gradle.org/8.2.1/userguide/toolchains.html#sec:auto_detection.
> Learn more about toolchain repositories at https://docs.gradle.org/8.2.1/userguide/toolchains.html#sub:download_repositories.

```
The documentation for the fix is available [here](https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning).
