### PR TITLE
Issue #120 fix - set fork working dir to temp dir

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
@@ -96,7 +96,7 @@ open class OpenApiGradlePlugin : Plugin<Project> {
 
 			// use original bootRun parameter if the list-type customBootRun properties are empty
 			workingDir = customBootRun.workingDir.asFile.orNull
-				?: fork.workingDir
+				?: fork.temporaryDir
 			args = customBootRun.args.orNull?.takeIf { it.isNotEmpty() }?.toMutableList()
 				?: bootRun.args?.toMutableList() ?: mutableListOf()
 			classpath = customBootRun.classpath.takeIf { !it.isEmpty }


### PR DESCRIPTION
Fixes https://github.com/springdoc/springdoc-openapi-gradle-plugin/issues/120

By default gradle-execfork-plugin [sets the working dir to the project directory](https://github.com/psxpaul/gradle-execfork-plugin?tab=readme-ov-file#execfork). This causes issues when running `generateOpenApiDocs` during a gradle `build`:
```
Reason: Task ':skeleton-server:forkedSpringBootRun' uses this output of task ':skeleton-server:bootJarMainClassName' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

Using a temporary directory instead of the project dir default [resolves this](https://github.com/springdoc/springdoc-openapi-gradle-plugin/issues/120#issuecomment-1903326454)