### PR TITLE
Added map property to set custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,24 @@ openApi {
     customBootRun {
         args.set(["--spring.profiles.active=special"]) 
     }
+    
+    requestHeaders = [
+       "x-forwarded-host": "custom-host",
+       "x-forwarded-port": "7000"
+    ]
 }
 ```
 
-| Parameter            | Description                                                                                                                         | Required | Default                              |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------------|
-| `apiDocsUrl`         | The URL from where the OpenAPI doc can be downloaded. If the url ends with `.yaml`, output will YAML format.                                                                                 | No       | http://localhost:8080/v3/api-docs    |
-| `outputDir`          | The output directory for the generated OpenAPI file                                                                                 | No       | $buildDir - Your project's build dir |
-| `outputFileName`     | Specifies the output file name.                            | No       | openapi.json                         |
+| Parameter            | Description                                                                                                                | Required | Default                              |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------------|
+| `apiDocsUrl`         | The URL from where the OpenAPI doc can be downloaded. If the url ends with `.yaml`, output will YAML format.               | No       | http://localhost:8080/v3/api-docs    |
+| `outputDir`          | The output directory for the generated OpenAPI file                                                                        | No       | $buildDir - Your project's build dir |
+| `outputFileName`     | Specifies the output file name.                                                                                            | No       | openapi.json                         |
 | `waitTimeInSeconds`  | Time to wait in seconds for your Spring Boot application to start, before we make calls to `apiDocsUrl` to download the OpenAPI doc | No       | 30 seconds                           |
-| `groupedApiMappings` | A map of URLs (from where the OpenAPI docs can be downloaded) to output file names                                                  | No       | []                                   |
-| `customBootRun`      | Any bootRun property that you would normal need to start your spring boot application.                                              | No       | (N/A)                                |
+| `groupedApiMappings` | A map of URLs (from where the OpenAPI docs can be downloaded) to output file names                                         | No       | []                                   |
+| `customBootRun`      | Any bootRun property that you would normal need to start your spring boot application.                                     | No       | (N/A)                                |
+| `requestHeaders`     | customize Generated server url, relies on `server.forward-headers-strategy=framework`                                      | No       | (N/A)                                |
+
 
 ### `customBootRun` properties examples
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.springdoc"
-version = "1.8.0"
+version = "1.8.1"
 
 sonarqube {
 	properties {

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiExtension.kt
@@ -20,6 +20,8 @@ open class OpenApiExtension @Inject constructor(
 	val waitTimeInSeconds: Property<Int> = objects.property(Int::class.java)
 	val groupedApiMappings: MapProperty<String, String> =
 		objects.mapProperty(String::class.java, String::class.java)
+	val requestHeaders: MapProperty<String, String> =
+		objects.mapProperty(String::class.java, String::class.java)
 	val customBootRun: CustomBootRunAction =
 		objects.newInstance(CustomBootRunAction::class.java)
 

--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGeneratorTask.kt
@@ -38,8 +38,13 @@ open class OpenApiGeneratorTask : DefaultTask() {
 	val groupedApiMappings: MapProperty<String, String> =
 		project.objects.mapProperty(String::class.java, String::class.java)
 
+	@get:Input
+	val requestHeaders: MapProperty<String, String> =
+		project.objects.mapProperty(String::class.java, String::class.java)
+
 	@get:OutputDirectory
 	val outputDir: DirectoryProperty = project.objects.directoryProperty()
+
 	@get:Internal
 	val waitTimeInSeconds: Property<Int> =
 		project.objects.property(Int::class.java)
@@ -56,6 +61,7 @@ open class OpenApiGeneratorTask : DefaultTask() {
 		groupedApiMappings.convention(extension.groupedApiMappings)
 		outputDir.convention(extension.outputDir)
 		waitTimeInSeconds.convention(extension.waitTimeInSeconds)
+		requestHeaders.convention(extension.requestHeaders)
 	}
 
 	@TaskAction
@@ -77,6 +83,10 @@ open class OpenApiGeneratorTask : DefaultTask() {
 				val connection: HttpURLConnection =
 					URL(url).openConnection() as HttpURLConnection
 				connection.requestMethod = "GET"
+				requestHeaders.get().forEach { header ->
+					connection.setRequestProperty(header.key, header.value)
+				}
+
 				connection.connect()
 				val statusCode = connection.responseCode
 				logger.trace("apiDocsUrl = {} status code = {}", url, statusCode)
@@ -86,6 +96,9 @@ open class OpenApiGeneratorTask : DefaultTask() {
 			val connection: HttpURLConnection =
 				URL(url).openConnection() as HttpURLConnection
 			connection.requestMethod = "GET"
+			requestHeaders.get().forEach { header ->
+				connection.setRequestProperty(header.key, header.value)
+			}
 			connection.connect()
 
 			val response = String(connection.inputStream.readBytes(), Charsets.UTF_8)

--- a/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
+++ b/src/test/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePluginTest.kt
@@ -362,11 +362,7 @@ class OpenApiGradlePluginTest {
 		assertOpenApiJsonFile(1, outputJsonFileName)
 		val openApiJson = getOpenApiJsonAtLocation(File(buildDir, outputJsonFileName))
 		val servers: JsonArray<Map<String, String>>? = openApiJson.array("servers")
-		assertTrue(
-			servers!!.contains(
-				mapOf("url" to "http://$customHost:$customPort", "description" to "Generated server url")
-			)
-		)
+		assertTrue(servers!!.any { s -> s.get("url").equals("http://$customHost:$customPort") })
 	}
 
 	private fun runTheBuild(vararg additionalArguments: String = emptyArray()) =


### PR DESCRIPTION
#145  ability to add headers to httpclient to customize json generatedUrl value similar to https://github.com/springdoc/springdoc-openapi-maven-plugin?tab=readme-ov-file#custom-settings-of-the-springdoc-openapi-maven-plugin