### PR TITLE
Use the bootRun javaLauncher in fork task

### DIFF
--- a/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
+++ b/src/main/kotlin/org/springdoc/openapi/gradle/plugin/OpenApiGradlePlugin.kt
@@ -110,6 +110,11 @@ open class OpenApiGradlePlugin : Plugin<Project> {
 				?: bootRun.jvmArgs
 			environment = customBootRun.environment.orNull?.takeIf { it.isNotEmpty() }
 				?: bootRun.environment
+
+			// Respect javaLauncher configured for bootRun, so Gradle JVM version
+			// (which may differ) is not used.
+			javaLauncher.set(bootRun.javaLauncher)
+
 			if (Jvm.current().toString().startsWith("1.8")) {
 				killDescendants = false
 			}


### PR DESCRIPTION
Verified in a new Spring initializer project (plus springdoc and plugin) for both Java and Kotlin.

For Java, choose Java 24 as toolchain version in build.gradle but configure Gradle JVM to Java 23 or earlier.

For Kotlin, use Java 21 as bytecode version, but for illustrative purposes, downgrade Gradle JVM to Java 19 for example.

LinkageError, java.lang.UnsupportedClassVersionError occurs in forkedSpringBootRun task in both cases (but with different encountered versus supported class file versions)